### PR TITLE
Fix heap buffer overflow caused by not allocating space for the NULL terminator

### DIFF
--- a/BB_Dictionary/BB_Dictionary.c
+++ b/BB_Dictionary/BB_Dictionary.c
@@ -38,7 +38,7 @@ void store(Dictionary *dict, char *key, void *val, int (*hashPtr)(char *)) {
     if (dict->items[hval] == NULL) {
         
         NODE *newN = (NODE *)malloc(sizeof(NODE));
-        char *tmpkey = malloc(sizeof(char)*strlen(key));
+        char *tmpkey = malloc(sizeof(char)*(strlen(key) + 1));
         strcpy(tmpkey, key);
         newN->key = tmpkey;
         newN->value = val;

--- a/BB_Dictionary/main.c
+++ b/BB_Dictionary/main.c
@@ -44,7 +44,7 @@ int main(int argc, const char * argv[]) {
         token = strtok(buf, t);
         
         for(int i=0; token!=NULL; i++) {
-            char *c = (char *)malloc(sizeof(char)*strlen(token));
+            char *c = (char *)malloc(sizeof(char)*(strlen(token) + 1));
             strcpy(c, token);
             //printf("%s", token);
             store(myDict, token, c, hash);


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).