### PR TITLE
Initialize uninitialized memory that results in a buffer overread

### DIFF
--- a/BB_Dictionary/BB_Dictionary.c
+++ b/BB_Dictionary/BB_Dictionary.c
@@ -27,7 +27,7 @@ struct dictionary_struct {
 
 Dictionary *create(int size) {
     Dictionary *newDict = (Dictionary *)malloc(sizeof(Dictionary));
-    newDict->items = malloc(size*sizeof(NODE *));
+    newDict->items = calloc(size, sizeof(NODE *));
     return newDict;
 }
 


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).