### PR TITLE
Allocate enough space for the NULL terminator to prevent oob access in strtok

### DIFF
--- a/BB_Dictionary/main.c
+++ b/BB_Dictionary/main.c
@@ -40,7 +40,7 @@ int main(int argc, const char * argv[]) {
     
     char buf[1000];
     while (fgets(buf,1000, wordsfd)!=NULL) {
-        const char t[2] = " \n";
+        const char t[3] = " \n";
         token = strtok(buf, t);
         
         for(int i=0; token!=NULL; i++) {


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).